### PR TITLE
Collector service: fix Python dependency of PyYAML module due to Cython 3 release - closes #2

### DIFF
--- a/stack/telegraf/pip-licenses.md
+++ b/stack/telegraf/pip-licenses.md
@@ -7,7 +7,7 @@ $ pip-licenses --with-urls --with-system --format=markdown
 
 | Name               | Version    | License                              | URL                                          |
 |--------------------|------------|--------------------------------------|----------------------------------------------|
-| PyYAML             | 6.0        | MIT License                          | https://pyyaml.org/                          |
+| PyYAML             | 6.0.1        | MIT License                          | https://pyyaml.org/                          |
 | certifi            | 2022.12.7  | Mozilla Public License 2.0 (MPL 2.0) | https://github.com/certifi/python-certifi    |
 | charset-normalizer | 2.1.1      | MIT License                          | https://github.com/ousret/charset_normalizer |
 | idna               | 3.4        | BSD License                          | https://github.com/kjd/idna                  |

--- a/stack/telegraf/requirements.txt
+++ b/stack/telegraf/requirements.txt
@@ -1,6 +1,6 @@
 pytz==2023.3
 raritan==20210223.0
-pyyaml==6.0
+pyyaml==6.0.1
 imcsdk==0.9.12
 requests==2.31.0
 ucsmsdk==0.9.13


### PR DESCRIPTION
## Description

Fixes issue https://github.com/cisco-open/green-monitoring/issues/2:

>  Collector service fails when resolving dependencies for Python module pyyaml==6.0 due to the release of Cython 3.
>  See this discussion for more context: https://github.com/yaml/pyyaml/issues/724.

Proposed resolution:

> enforce compatible version of PyYAML: pyyaml==6.0.1.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
